### PR TITLE
Avoid watching tmp/ and dist/ folders on Ubuntu

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
       var MakeHumansTXT = require('./lib/broccoli/make-humans-txt');
       var humans = this._getHumansConfig();
 
-      return new MakeHumansTXT('.', humans);
+      return new MakeHumansTXT(humans);
     }
   },
 

--- a/lib/broccoli/make-humans-txt.js
+++ b/lib/broccoli/make-humans-txt.js
@@ -7,8 +7,9 @@ module.exports = MakeHumansBroccoli;
 MakeHumansBroccoli.prototype = Object.create(Plugin.prototype);
 MakeHumansBroccoli.prototype.constructor = MakeHumansBroccoli;
 
-function MakeHumansBroccoli(inputNode, definition) {
-  Plugin.call(this, [inputNode]);
+function MakeHumansBroccoli(definition) {
+  // We don't need any input node
+  Plugin.call(this, []);
 
   this.definition = definition;
 }

--- a/node-tests/broccoli/make-humans-txt-test.js
+++ b/node-tests/broccoli/make-humans-txt-test.js
@@ -13,8 +13,8 @@ describe('Broccoli: MakeHumansTXT', function() {
   var MakeHumansTXTHelper = makeTestHelper({
     fixturePath: __dirname,
 
-    subject: function(inputNode) {
-      return new MakeHumansTXT(inputNode, {
+    subject: function() {
+      return new MakeHumansTXT({
         team: 'Neil Young (@Neilyoung on Twitter)'
       });
     },
@@ -25,7 +25,7 @@ describe('Broccoli: MakeHumansTXT', function() {
   });
 
   it('generates humans.txt file', function() {
-    return MakeHumansTXTHelper('fixtures')
+    return MakeHumansTXTHelper()
       .then(function(result) {
         assert.deepEqual(result.files, ['humans.txt']);
         return path.join(result.directory, result.files[0]);


### PR DESCRIPTION
Under some conditions we were watching the tmp/ and dist/ folders making
`ember serve` to go crazy and never stop building the application.

By specifying the source nodes as an empty array we avoid this.